### PR TITLE
Fix Toast message supporting longer messages

### DIFF
--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -16,6 +16,7 @@
   flex: 1;
   padding: 12px 0px;
   font-weight: 600;
+  overflow: auto;
 }
 
 .iconContainer {


### PR DESCRIPTION
The current Toast message does not support longer messages and will push the dismiss button out of the container and overflow. This sets the content to handle this automatically and wrap text content.